### PR TITLE
fix an error: can't show the bookmark which url contain "&"

### DIFF
--- a/src/alfmarks.php
+++ b/src/alfmarks.php
@@ -37,7 +37,9 @@ class BookmarkModel {
 		$item->addAttribute('arg', $this->data['url']);
 		$item->addAttribute('uid', $this->data['id']);
 		$item->addChild('title', $this->data['name']);
-		$item->addChild('subtitle', $this->data['url']);
+		// $item->addChild('subtitle', $this->data['url']);
+		// to make it recognize "&" in the url correctly
+		$item->subtitle = $this->data['url'];
 		return $item;
 	}
 


### PR DESCRIPTION
change method of the url of bookmark added into the xml.
to make it correctly recognize the "&" in the url.

when I test it for myself, I find that it can't show the bookmark contain "&"
