### PR TITLE
Mock Helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
 
 before_install:
   - php composer.phar install --dev

--- a/tests/Unit.php
+++ b/tests/Unit.php
@@ -2,16 +2,86 @@
 
 class Unit extends PHPUnit_Framework_TestCase {
 
-	public function subject($params = array(), $options = array()) {
-		$options += array(
-			'mock' => false,
-			'methods' => array(),
-		);
-		$class = 'alfmarks\\' . str_replace('Test', '', get_called_class());
-		if ($options['mock']) {
-			return $this->getMock($class, $options['methods'], $params);
+	public static $classNamespace = "alfmarks\\";
+
+	private $subjectClass;
+	private $subjectParams = array();
+	private $subjectOptions;
+
+	private $baseParams = array();
+
+	private $baseOptions = array(
+		'mock' => false,
+		'methods' => array()
+	);
+
+	public function __construct( ...$class ) {
+		if (!empty($class)) {
+			// Since we took in a splat
+			foreach($class as $klass) {
+				$this->subjectClass = $klass;
+			}
+		} else {
+			parent::__construct();
 		}
-		return new $class($params);
+	}
+
+	public static function getCalledClass() {
+		$calledClass = str_replace(
+			'Test', '', get_called_class()
+		);
+		return self::$classNamespace . $calledClass;
+	}
+
+	public function withParams( ...$params ) {
+		// we use the pairs as `option => value` options
+		$count = 1;
+		$ks = array_keys($this->baseParams);
+		$vs = array_values($this->baseParams);
+		foreach($params as $param) {
+			// Odd counts are arg keys
+			if (($count % 2) == 1) { $ks[] = $param; }
+			// Even counts are arg values
+			if (($count % 2) == 0) { $vs[] = $param; }
+			$count++;
+		}
+		// If two keys are the same the second prevails
+		// so this accounts for override of baseParams
+		$this->subjectParams = array_combine($ks, $vs);
+		// Since this is a chainable method
+		return $this;
+	}
+
+	public function withOptions( ...$options ) {
+		// we use the pairs as `option => value` options
+		$count = 1;
+		$ks = array_keys($this->baseOptions);
+		$vs = array_values($this->baseOptions);
+		foreach($options as $option) {
+			// Odd counts are arg keys
+			if (($count % 2) == 1) { $ks[] = $option; }
+			// Even counts are arg values
+			if (($count % 2) == 0) { $vs[] = $option; }
+			$count++;
+		}
+		// If two keys are the same the second prevails
+		// so this accounts for override of baseOptions
+		$this->subjectOptions = array_combine($ks, $vs);
+		// Since this is a chainable method
+		return $this;
+	}
+
+	public function buildSubject() {
+		// If we are mocking the class
+		if ($this->subjectOptions['mock']) {
+			return $this->getMock($this->subjectClass,
+				$this->subjectOptions['methods'],
+				$this->subjectParams
+			);
+		}
+		// Otherwise initialize an instance w/ params
+		return new $this->subjectClass( $this->subjectParams );
 	}
 
 }
+

--- a/tests/src/BookmarkCollectionTest.php
+++ b/tests/src/BookmarkCollectionTest.php
@@ -10,10 +10,4 @@ class BookmarkCollectionTest extends Unit {
 		$this->assertEquals($result, $expected);
 	}
 
-	public function callsToXmlOnNodes() {
-		$stub = $this->getMockBuilder('stdclass')->getMock();
-		$stub->expects($this->once())->method('to_xml');
-		$this->subject(array($stub))->to_xml();
-	}
-
 }

--- a/tests/src/BookmarkCollectionTest.php
+++ b/tests/src/BookmarkCollectionTest.php
@@ -4,10 +4,19 @@ use alfmarks\BookmarkCollection;
 
 class BookmarkCollectionTest extends Unit {
 
+	public function setUp() {
+		$this->classTester = new Unit(self::getCalledClass());
+	}
+
 	public function testReturnsEmptyItemArray() {
-		$result = $this->subject()->to_xml();
-		$expected = "<?xml version=\"1.0\"?>\n<items/>\n";
-		$this->assertEquals($result, $expected);
+		$this->assertEquals(
+			"<?xml version=\"1.0\"?>\n<items/>\n",
+			$this
+				->classTester
+				->buildSubject()
+				->to_xml()
+		);
 	}
 
 }
+

--- a/tests/src/BookmarkModelTest.php
+++ b/tests/src/BookmarkModelTest.php
@@ -4,24 +4,43 @@ use alfmarks\BookmarkModel;
 
 class BookmarkModelTest extends Unit {
 
+	public function setUp() {
+		$this->classTester = new Unit(self::getCalledClass());
+	}
+
 	public function testToXml() {
-		$result = $this->subject(array(
-			'url' => 'http://google.com',
-			'id' => '10',
-			'name' => 'Google',
-		))->to_xml()->asXML();
-		$expected = '<item arg="http://google.com" uid="100"><title>Google</title><subtitle>http://google.com</subtitle></item>';
-		$this->assertEquals($expected, $result);
+		$this->assertEquals(
+			'<item arg="http://google.com" uid="100">'.
+			'<title>Google</title>'.
+			'<subtitle>http://google.com</subtitle></item>',
+			$this
+				->classTester
+				->withParams(
+					'url',  'http://google.com',
+					'id',   '10',
+					'name', 'Google')
+				->buildSubject()
+				->to_xml()
+				->asXML()
+		);
 	}
 
 	public function testToXmlWithAmp() {
-		$result = $this->subject(array(
-			'url' => 'http://google.com?foo&bar',
-			'id' => '10',
-			'name' => 'Google',
-		))->to_xml()->asXML();
-		$expected = '<item arg="http://google.com?foo&amp;bar" uid="100"><title>Google</title><subtitle>http://google.com?foo&amp;bar</subtitle></item>';
-		$this->assertEquals($expected, $result);
+		$this->assertEquals(
+			'<item arg="http://google.com?foo&amp;bar" uid="100">'.
+			'<title>Google</title>'.
+			'<subtitle>http://google.com?foo&amp;bar</subtitle></item>',
+			$this
+				->classTester
+				->withParams(
+					'url',  'http://google.com?foo&bar',
+					'id',   '10',
+					'name', 'Google')
+				->buildSubject()
+				->to_xml()
+				->asXML()
+		);
 	}
 
 }
+

--- a/tests/src/QueryTest.php
+++ b/tests/src/QueryTest.php
@@ -16,4 +16,8 @@ class QueryTest extends Unit {
 		$this->assertEquals('/.*?((f).*?(o).*?(o)).*?|.*?((f).*?(o)).*?|.*?((o).*?(o)).*?/i', $this->subject(array('term' => 'foo'))->regex());
 	}
 
+	public function testTermWithCharacters() {
+		$this->assertEquals('/.*?((\]).*?(\[).*?(\^)).*?|.*?((\]).*?(\[)).*?|.*?((\[).*?(\^)).*?/i', $this->subject(array('term' => '][^'))->regex());
+	}
+
 }

--- a/tests/src/QueryTest.php
+++ b/tests/src/QueryTest.php
@@ -4,20 +4,58 @@ use alfmarks\Query;
 
 class QueryTest extends Unit {
 
+	public function setUp() {
+		$this->classTester = new Unit(self::getCalledClass());
+	}
+
 	public function testSetsModel() {
-		$this->assertEquals('foo', $this->subject(array('model' => 'foo'))->model);
+		// A `Query` with a model assigned to `foo` call model should return `foo`.
+		$this->assertEquals(
+			'foo',
+			$this
+				->classTester
+				->withParams('model', 'foo')
+				->buildSubject()
+				->model
+		);
 	}
 
 	public function testSetsTerm() {
-		$this->assertEquals('foo', $this->subject(array('term' => 'foo'))->term);
+		// A `Query` with a term assigned to `foo` call term should return `foo`.
+		$this->assertEquals(
+			'foo',
+			$this
+				->classTester
+				->withParams('term', 'foo')
+				->buildSubject()
+				->term
+		);
 	}
 
 	public function testTerm() {
-		$this->assertEquals('/.*?((f).*?(o).*?(o)).*?|.*?((f).*?(o)).*?|.*?((o).*?(o)).*?/i', $this->subject(array('term' => 'foo'))->regex());
+		// A `Query` with a term assigned to `foo` call regex should return `pattern`.
+		$this->assertEquals(
+			'/.*?((f).*?(o).*?(o)).*?|.*?((f).*?(o)).*?|.*?((o).*?(o)).*?/i',
+			$this
+				->classTester
+				->withParams('term', 'foo')
+				->buildSubject()
+				->regex()
+		);
 	}
 
 	public function testTermWithCharacters() {
-		$this->assertEquals('/.*?((\]).*?(\[).*?(\^)).*?|.*?((\]).*?(\[)).*?|.*?((\[).*?(\^)).*?/i', $this->subject(array('term' => '][^'))->regex());
+		// A `Query` with a term assigned to `][^` call regex should return...
+		// a corrected pattern with escape backslash `\` before caret `^` symbols.
+		$this->assertEquals(
+			'/.*?((\]).*?(\[).*?(\^)).*?|.*?((\]).*?(\[)).*?|.*?((\[).*?(\^)).*?/i',
+			$this
+				->classTester
+				->withParams('term', '][^')
+				->buildSubject()
+				->regex()
+		);
 	}
 
 }
+

--- a/tests/src/SourceTest.php
+++ b/tests/src/SourceTest.php
@@ -16,6 +16,7 @@ class SourceTest extends Unit {
 
 	public function setUp() {
 		$this->root = vfsStream::setup('home');
+		$this->classTester = new Unit(self::getCalledClass());
 	}
 
 	public function tearDown() {
@@ -42,10 +43,12 @@ class SourceTest extends Unit {
 				'url' => 'http://yahoo.com',
 			),
 		));
-		$subject = $this->subject(array(), array(
-			'mock' => true,
-			'methods' => array('normalizeFile'),
-		));
+		$subject = $this->classTester
+			->withOptions(
+				'mock',    true,
+				'methods', array('normalizeFile')
+			)
+			->buildSubject();
 		$subject->expects($this->any())
 			->method('normalizeFile')
 			->will($this->returnValue($_SERVER['PROFILE']));
@@ -81,10 +84,12 @@ class SourceTest extends Unit {
 				'url' => 'http://yahoo.com',
 			),
 		));
-		$subject = $this->subject(array(), array(
-			'mock' => true,
-			'methods' => array('normalizeFile'),
-		));
+		$subject = $this->classTester
+			->withOptions(
+				'mock',    true,
+				'methods', array('normalizeFile')
+			)
+			->buildSubject();
 		$subject->expects($this->any())
 			->method('normalizeFile')
 			->will($this->returnValue($_SERVER['PROFILE']));
@@ -127,10 +132,12 @@ class SourceTest extends Unit {
 		Mock::filter('glob', function($pattern) use ($files) {
 				return $files;
 		});
-		$subject = $this->subject(array(), array(
-			'mock' => true,
-			'methods' => array('normalizeFile'),
-		));
+		$subject = $this->classTester
+			->withOptions(
+				'mock',    true,
+				'methods', array('normalizeFile')
+			)
+			->buildSubject();
 		$subject->expects($this->any())
 			->method('normalizeFile')
 			->will($this->returnValue($_SERVER['PROFILE']));
@@ -155,7 +162,9 @@ class SourceTest extends Unit {
 	}
 
 	public function testNormalizeGivesBackNodes() {
-		$result = $this->subject()->normalizeData(range(1,2), function() {
+		$subject = $this->classTester
+			->buildSubject();
+		$result = $subject->normalizeData(range(1,2), function() {
 			return 'yes';
 		});
 		$expected = array('yes');
@@ -163,3 +172,4 @@ class SourceTest extends Unit {
 	}
 
 }
+


### PR DESCRIPTION
- Enhanced the mock helper give a more fluent api for expression on how you would like your mock object back from the helper. 
- Refactored tests to use the new syntax.

May want to take this a little further but wanted to wait until I get some feedback on the approach.

This causes us to need to use php 5.6 for running tests, (so travis may break on CI right now) since I am using splats in functions.

( see https://travis-ci.org/blainesch/alfred-chrome-bookmarks/jobs/91126534 )