### PR TITLE
Support Unicode

### DIFF
--- a/src/alfmarks.php
+++ b/src/alfmarks.php
@@ -53,7 +53,7 @@ class BookmarkModel {
 
 	public static function find($term) {
 		$source = new Source();
-		$data = $source->read(new Query(array('term' => $term, 'model' => __CLASS__)));
+		$data = $source->read(new Query(array('term' => normalizer_normalize($term), 'model' => __CLASS__)));
 		return new BookmarkCollection($data);
 	}
 }


### PR DESCRIPTION
Workflow always fails when the search term contains Unicode like "구글"
"구글" means "Google" in Korean.
